### PR TITLE
sync after writing and renaming

### DIFF
--- a/src/signer/tests.rs
+++ b/src/signer/tests.rs
@@ -39,7 +39,7 @@ fn signer_with_mock_connection() {
         step: 0.into(),
     };
 
-    let cd_path = "asd";
+    let cd_path = "./asd";
     std::fs::write(
         cd_path,
         &serde_json::to_string(&initial_cd).unwrap().as_bytes(),


### PR DESCRIPTION
if we have a crash or power loss before the buffer is flushed we can have an empty or a partially written file, this aims to force commit of the file data to stable storage

this also requires the parent dir to exist so a path like "state.json" needs to be in form of "./state.json" 